### PR TITLE
Support Emacs 23 and 24

### DIFF
--- a/elisp-lint.el
+++ b/elisp-lint.el
@@ -7,7 +7,7 @@
 ;; Author: Neil Okamoto <neil.okamoto+melpa@gmail.com>
 ;; Version: 0.2
 ;; Keywords: lisp, maint, tools
-;; Package-Requires: ((emacs "25"))
+;; Package-Requires: ((emacs "23"))
 ;; URL: http://github.com/gonewest818/elisp-lint/
 ;;
 ;; This file is NOT part of GNU Emacs.
@@ -52,14 +52,14 @@
 ;;    - Whitespace check permits page-delimiter (^L)
 ;;    - Indentation check prints the diff to console
 ;;    - User can specify indent specs to tell the checker about macros
-;;    - Added checkdoc (require Emacs 25 and newer)
+;;    - Added checkdoc (available only Emacs 25 and newer)
 ;;    - Cleared up the console output for easier reading in CI
 ;;    - Expand Travis CI test matrix to include Emacs 25 and 26
 ;;
 ;;; Code:
 
 (require 'bytecomp)
-(require 'checkdoc)
+(require 'checkdoc nil t)
 (require 'package nil t)
 
 (declare-function package-buffer-info "package" t)


### PR DESCRIPTION

This PR makes the `checkdoc` requirement conditional, so that all the other checks are still available in Emacs version prior to 25.