### PR TITLE
accessing ELPA requires updated gpg keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ BACKUPS = $(ELS:.el=.el~) $(TESTS:.el=.el~)
 .PHONY: version lint test clean cleanelpa
 
 .elpa:
+	mkdir -p .emacs/elpa/gnupg && \
+	chmod 700 .emacs/elpa/gnupg && \
+	echo "disable-ipv6" > .emacs/elpa/gnupg/dirmngr.conf && \
+	gpg --keyserver pool.sks-keyservers.net \
+	    --homedir .emacs/elpa/gnupg \
+	    --recv-keys 066DAFCB81E42C40
 	$(EMACS) $(BATCH)
 	touch .elpa
 


### PR DESCRIPTION
A recent commit added a dependency on `package-lint' which
transitively depends on `let-alist` 1.0.6, which is in ELPA.

Because ELPA packages are now signed with a new gpg key, we need to
receive that key from a keyserver before accessing ELPA. This
Makefile change will work locally and in CircleCI.