### PR TITLE
Make the variable added in commit bf72aee public: `elisp-lint-no-color'

### DIFF
--- a/elisp-lint.el
+++ b/elisp-lint.el
@@ -434,16 +434,17 @@ Allow `page-delimiter' if it is alone on a line."
     (white   . 37))
   "ANSI color escape codes.")
 
-(defconst elisp-lint--no-color
+(defvar elisp-lint-no-color
   (let ((term (getenv-internal "TERM"))
         (no-color (getenv-internal "NO_COLOR")))
     (or (and (stringp term) (string= term "dumb"))
         (and (stringp no-color) (> (length no-color) 0))))
-  "Disable colored text via the environment: NO_COLOR non-empty OR TERM=dumb.")
+  "Disable colored text via the environment: NO_COLOR non-empty OR TERM=dumb.
+Can also be changed programmatically.")
 
 (defun elisp-lint--print (color fmt &rest args)
   "Print output text in COLOR, formatted according to FMT and ARGS."
-  (if elisp-lint--no-color
+  (if elisp-lint-no-color
       (progn
         (princ (apply #'format fmt args))
         (terpri))


### PR DESCRIPTION
This is a minor change suggested by me in #31, and also agreed to by the original author of `...-no-color` change.

To quote:

> Would be nice if elisp-lint--no-color was made public (i.e. elisp-lint-no-color) instead and settable (defvar instead of defconst). For any tool that integrates with the linter (in my case it's Eldev), it might be a desired thing to forward a higher-level setting to the linter. And it's always better to go via public interface and not meddle with private variables.