### PR TITLE
Permit long lines if a URL is present on it

### DIFF
--- a/elisp-lint.el
+++ b/elisp-lint.el
@@ -83,6 +83,7 @@
 (require 'package)
 (require 'package-lint)
 (require 'subr-x)
+(require 'url)
 (require 'dash)
 
 (defconst elisp-lint-file-validators
@@ -367,6 +368,16 @@ Use a file variable or \".dir-locals.el\" to override the default value."
   "^;;[ \t]+Package-Requires:"
   "This regexp must match the definition in package.el.")
 
+(defvar elisp-lint--url-regexp
+  "[a-zA-Z][-a-zA-Z0-9+.]*://"
+  "Matches text that (probably) contains a URL.
+
+   As a heuristic, the presence of a type (scheme) and `//' is
+   used.  Other parts of the URL are not considered, since pretty
+   much anything may be part of a legitimate URL.  This neither
+   matches all possible URLs, nor does it match all non-URLs, but
+   it should be good enough.")
+
 (defun elisp-lint--fill-column ()
   "Confirm buffer has no lines exceeding `fill-column' in length.
 Use a file variable or \".dir-locals.el\" to override the default
@@ -393,6 +404,7 @@ have unlimited length:
           (when
               (and (not (string-match elisp-lint--package-summary-regexp text))
                    (not (string-match elisp-lint--package-requires-regexp text))
+                   (not (string-match elisp-lint--url-regexp text))
                    (> (length text) fill-column))
             (push (list line-number 0 'fill-column
                         (format "line length %s exceeded" fill-column))


### PR DESCRIPTION
I looked at #21 and noticed that most of us just want exceptions for when URLs cause really long lines. This covers that use case, which looks like it's good enough most of the time for now.

The current heuristic just looks for things like `http://`, because I think stuff like this is reasonable, but would be rejected if the heuristic was stricter:

```elisp
(setq long-url "https://github.com/gonewest818/elisp-lint/blob/a5ae046c35a898a88eff05137fe9e5159ae610d8/elisp-lint.el")
```

Another good heuristic may be `^[[:blank:];]*[[:graph:]]+$`, which while it would reject the above, would instead match any really long running single-"word". Generally only URLs, or at least things that cannot be broken up like filenames, match this heuristic. Pycodestyle uses this heuristic too. Happy to switch to that if that is preferred.