### PR TITLE
Proposal: add magic comment <elisp-lint-ignore-fill>

### DIFF
--- a/elisp-lint.el
+++ b/elisp-lint.el
@@ -380,6 +380,12 @@ Use a file variable or \".dir-locals.el\" to override the default value."
           "$")
   "This regexp must match a URL in comments or strings.")
 
+(defvar elisp-lint--ignore-fill-re
+  ";+[[:blank:]]*<elisp-lint-ignore-fill>[[:blank:]]*$")
+
+(defvar elisp-lint--resume-fill-re
+  ";+[[:blank:]]*<elisp-lint-resume-fill>[[:blank:]]*$")
+
 (defun elisp-lint--fill-column ()
   "Confirm buffer has no lines exceeding `fill-column' in length.
 Use a file variable or \".dir-locals.el\" to override the default
@@ -405,14 +411,20 @@ have unlimited length:
         (let ((text (buffer-substring-no-properties
                      (line-beginning-position)
                      (line-end-position))))
-          (when
-              (and (not (string-match elisp-lint--package-summary-regexp text))
-                   (not (string-match elisp-lint--package-requires-regexp text))
-                   (not (string-match elisp-lint--url-in-document-regexp text))
-                   (> (length text) fill-column))
-            (push (list line-number 0 'fill-column
-                        (format "line length %s exceeded" fill-column))
-                  too-long-lines)))
+          (if (string-match-p elisp-lint--ignore-fill-re text)
+              (let ((start (point))
+                    (end (progn
+                           (re-search-forward elisp-lint--resume-fill-re nil :move)
+                           (point))))
+                (setq line-number (+ line-number (count-matches "\n" start end))))
+            (when
+                (and (not (string-match elisp-lint--package-summary-regexp text))
+                     (not (string-match elisp-lint--package-requires-regexp text))
+                     (not (string-match elisp-lint--url-in-document-regexp text))
+                     (> (length text) fill-column))
+              (push (list line-number 0 'fill-column
+                          (format "line length %s exceeded" fill-column))
+                    too-long-lines))))
         (setq line-number (1+ line-number))
         (forward-line 1))
       too-long-lines)))


### PR DESCRIPTION
This code is just one way to do it. It shows that the implementation can be simple.

It enables you to mark boundaries of regions in which not to lint the line-lengths. Example:

```elisp
(defconst some-huge-verbatim-sql-code-string  ;; <elisp-lint-ignore-fill>
  "
SELECT
        title,
        aliases,
        id,
        file,
        filetitle,
        \"level\",
        todo,
        pos,
        priority,
        scheduled,
        deadline,
        properties,
        olp,
        atime,
        mtime,
        '(' || group_concat(tags, ' ') || ')' AS tags,
        refs
FROM (
        SELECT
                id,
                file,
                filetitle,
                \"level\",
                todo,
                pos,
                priority,
                scheduled,
                deadline,
                title,
                properties,
                olp,
                atime,
                mtime,
                tags,
                '(' || group_concat(aliases, ' ') || ')' AS aliases,
                refs
        FROM (
                SELECT
                        nodes.id AS id,
                        nodes.file AS file,
                        nodes.\"level\" AS \"level\",
                        nodes.todo AS todo,
                        nodes.pos AS pos,
                        nodes.priority AS priority,
                        nodes.scheduled AS scheduled,
                        nodes.deadline AS deadline,
                        nodes.title AS title,
                        nodes.properties AS properties,
                        nodes.olp AS olp,
                        files.atime AS atime,
                        files.mtime AS mtime,
                        files.title AS filetitle,
                        tags.tag AS tags,
                        aliases.alias AS aliases,
                        '(' || group_concat(RTRIM(refs. \"type\", '\"') || ':' || LTRIM(refs.ref, '\"'), ' ') || ')' AS refs
                FROM
                        nodes
                LEFT JOIN files ON files.file = nodes.file
                LEFT JOIN tags ON tags.node_id = nodes.id
                LEFT JOIN aliases ON aliases.node_id = nodes.id
                LEFT JOIN refs ON refs.node_id = nodes.id
        GROUP BY
                nodes.id,
                tags.tag,
                aliases.alias)
GROUP BY
        id,
        tags)
GROUP BY
        id
") ;; <elisp-lint-resume-fill>
```


In the interest of simple UX, I think it'd make sense to generalize this to just `;; <elisp-lint-ignore>`, ignoring all linters and not just the fill-column linter, but I don't know if that may complicate the implementation.

Another good idea is https://github.com/gonewest818/elisp-lint/issues/37, but elisp-lint does seem to operate on a line-by-line basis, so covering sexps would probably require a heavier refactor.